### PR TITLE
Fixing dimension order: natural_image_reader_writer.py

### DIFF
--- a/nnunetv2/imageio/natural_image_reader_writer.py
+++ b/nnunetv2/imageio/natural_image_reader_writer.py
@@ -44,7 +44,7 @@ class NaturalImage2DIO(BaseReaderWriter):
                                                                          "dimension must have shape 3 or 4 " \
                                                                          f"(RGB or RGBA). Image shape here is {npy_img.shape}"
                 # move RGB(A) to front, add additional dim so that we have shape (1, c, X, Y), where c is either 3 or 4
-                images.append(npy_img.transpose((2, 0, 1))[:, None])
+                images.append(npy_img.transpose((2, 0, 1))[None,:])
             elif npy_img.ndim == 2:
                 # grayscale image
                 images.append(npy_img[None, None])


### PR DESCRIPTION
Fixing that additional dimension is added in front, such that new shape is (1,c,X,Y). If not, this is causing an "Error: Unexpected number of modalities" during verify for RGB images.